### PR TITLE
Change element mechanics and logic

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,12 +33,13 @@ The key to memorizing the resource dependency relationships is thinking about wh
 
 There are two ways this affects mechanics in the game:
 
-1. Heals being stronger (+3, -1) (if weapon->healed or healer->healed). Heals are stronger and users loses health. Heal amplification stacks but health loss does not.
+1. Heals being stronger (+2, -1) (if weapon->healed or healer->healed). Heals are stronger and users loses health. Heal amplification stacks but health loss does not.
 e.g. A healed fire type would be significantly healed by a wood healer with a wood healing weapon.
 
-2. Both heals and attacks are significantly stronger (+4, +4) (if fighter->weapon). If the fighter's element strengthens the weapon's element, then both heals and attacks are more far more effective at the cost of making the user weaker.
+2. Both heals and attacks are significantly stronger (+4, -2) (if fighter->weapon). If the fighter's element strengthens the weapon's element, then both heals and attacks are more far more effective at the cost of making the user weaker.
 e.g. A wood weapon would be greatly strengthened by a water fighter.
 
+Healers may die from healing.
 ---
 
 ## Effectiveness of Elements


### PR DESCRIPTION
Summary from README:

## Resource Dependency of Elements

The key to memorizing the resource dependency relationships is thinking about what consumes what (fire consumes wood).

1. Heals being stronger (+2, -1) (if weapon->healed or healer->healed). Heals are stronger and users loses health. Heal amplification stacks but health loss does not.
e.g. A healed fire type would be significantly healed by a wood healer with a wood healing weapon.

2. Both heals and attacks are significantly stronger (+4, -2) (if fighter->weapon). If the fighter's element strengthens the weapon's element, then both heals and attacks are more far more effective at the cost of making the user weaker.
e.g. A wood weapon would be greatly strengthened by a water fighter.

Healers may die from healing.
---

## Effectiveness of Elements

The key to memorizing effectiveness relationships is thinking about what eliminates what (water gets rid of fire).

There are two ways this affects mechanics in the game:

1. Attacks being stronger (+2) (if weapon->attacked or attacker->attacked): Attacks are stronger. Attack amplification stacks.
e.g. A fire type would be significantly hurt by a water fighter with a water weapon.

2. Attacks being significantly weaker (-4) (if attacked->weapon or attacked->attacker): Attacks are weaker. Attack amplification stacks.
e.g. A water victim would barely be hurt by a fire fighter with a fire weapon.


Closes #5.